### PR TITLE
#229 Add OpenTelemetry Collector Server Auth Extensions to Receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Main (unreleased)
 
 - Add relevant golang environment variables to the support bundle (@dehaansa)
 
+- Add support for server authentication to otelcol components. (@aidaleuc)
+
 ### Bugfixes
 
 - Fixed an issue in the `prometheus.exporter.postgres` component that would leak goroutines when the target was not reachable (@dehaansa)

--- a/docs/sources/reference/components/otelcol/otelcol.auth.headers.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.headers.md
@@ -11,6 +11,8 @@ title: otelcol.auth.headers
 `otelcol.auth.headers` exposes a `handler` that can be used by other `otelcol`
 components to authenticate requests using custom headers.
 
+This extension only supports client authentication. 
+
 {{< admonition type="note" >}}
 `otelcol.auth.headers` is a wrapper over the upstream OpenTelemetry Collector `headerssetter` extension.
 Bug reports or feature requests will be redirected to the upstream repository, if necessary.

--- a/docs/sources/reference/components/otelcol/otelcol.auth.oauth2.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.oauth2.md
@@ -10,6 +10,8 @@ title: otelcol.auth.oauth2
 
 `otelcol.auth.oauth2` exposes a `handler` that can be used by other `otelcol` components to authenticate requests using OAuth 2.0.
 
+This extension only supports client authentication. 
+
 The authorization tokens can be used by HTTP and gRPC based OpenTelemetry exporters.
 This component can fetch and refresh expired tokens automatically.
 Refer to the [OAuth 2.0 Authorization Framework](https://datatracker.ietf.org/doc/html/rfc6749#section-4.4) for more information about the Auth 2.0 Client Credentials flow.

--- a/docs/sources/reference/components/otelcol/otelcol.auth.sigv4.md
+++ b/docs/sources/reference/components/otelcol/otelcol.auth.sigv4.md
@@ -12,6 +12,8 @@ title: otelcol.auth.sigv4
 components to authenticate requests to AWS services using the AWS Signature Version 4 (SigV4) protocol.
 For more information about SigV4 see the AWS documentation about [Signing AWS API requests][].
 
+This extension only supports client authentication. 
+
 [Signing AWS API requests]: https://docs.aws.amazon.com/general/latest/gr/signing-aws-api-requests.html
 
 > **NOTE**: `otelcol.auth.sigv4` is a wrapper over the upstream OpenTelemetry

--- a/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
+++ b/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
@@ -305,6 +305,9 @@ otelcol.extension.jaeger_remote_sampling "default" {
   http {
     auth = otelcol.auth.basic.creds.handler
   }
+  grpc {
+     auth = otelcol.auth.basic.creds.handler
+  }
 }
 
 otelcol.auth.basic "creds" {

--- a/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
+++ b/docs/sources/reference/components/otelcol/otelcol.extension.jaeger_remote_sampling.md
@@ -79,6 +79,7 @@ Name                     | Type           | Description                         
 `max_request_body_size`  | `string`       | Maximum request body size the server will allow.                | `20MiB`          | no
 `include_metadata`       | `boolean`      | Propagate incoming connection metadata to downstream consumers. |                  | no
 `compression_algorithms` | `list(string)` | A list of compression algorithms the server can accept.         | `["", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"]` | no
+`auth`              | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.     |               | no
 
 ### tls block
 
@@ -125,6 +126,7 @@ Name                     | Type      | Description                              
 `read_buffer_size`       | `string`  | Size of the read buffer the gRPC server will use for reading from clients. | `"512KiB"`        | no
 `write_buffer_size`      | `string`  | Size of the write buffer the gRPC server will use for writing to clients.  |                   | no
 `include_metadata`       | `boolean` | Propagate incoming connection metadata to downstream consumers.            |                   | no
+`auth`              | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.     |               | no
 
 ### keepalive block
 
@@ -291,5 +293,22 @@ otelcol.extension.jaeger_remote_sampling "example" {
   source {
     content = local.file.sampling.content
   }
+}
+```
+
+## Enabling Authentication
+
+You can create a `jaeger_remote_sampling` extensions that requires authentication for requests. This is useful for limiting access to the sampling document. Note that not all OpenTelemetry Collector (otelcol) authentication plugins support receiver authentication. Please refer to the documentation for each `otelcol.auth.*` plugin to determine its compatibility.
+
+```alloy
+otelcol.extension.jaeger_remote_sampling "default" {
+  http {
+    auth = otelcol.auth.basic.creds.handler
+  }
+}
+
+otelcol.auth.basic "creds" {
+    username = sys.env("USERNAME")
+    password = sys.env("PASSWORD")
 }
 ```

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.datadog.md
@@ -38,6 +38,7 @@ Name                     | Type       | Description                             
 `include_metadata`       | `boolean`  | Propagate incoming connection metadata to downstream consumers.  | `false`            | no
 `read_timeout`           | `duration` | Read timeout for requests of the HTTP server.                    | `"60s"`            | no
 `compression_algorithms` | `list(string)` | A list of compression algorithms the server can accept.      | `["", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"]` | no
+`auth`              | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.     |               | no
 
 By default, `otelcol.receiver.datadog` listens for HTTP connections on `localhost`.
 To expose the HTTP server to other machines on your network, configure `endpoint` with the IP address to listen on, or `0.0.0.0:8126` to listen on all network interfaces.
@@ -132,6 +133,25 @@ otelcol.exporter.otlp "default" {
   client {
     endpoint = sys.env("OTLP_ENDPOINT")
   }
+}
+```
+
+## Enabling Authentication
+
+You can create a `datadog` receiver that requires authentication for requests. This is useful for limiting who can push data to the server. Note that not all OpenTelemetry Collector (otelcol) authentication plugins support receiver authentication. Please refer to the documentation for each `otelcol.auth.*` plugin to determine its compatibility.
+
+```alloy
+otelcol.receiver.datadog "default" {
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+    traces  = [otelcol.processor.batch.default.input]
+  }
+  auth = otelcol.auth.basic.creds.handler
+}
+
+otelcol.auth.basic "creds" {
+    username = sys.env("USERNAME")
+    password = sys.env("PASSWORD")
 }
 ```
 <!-- START GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.jaeger.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.jaeger.md
@@ -101,6 +101,7 @@ Name                     | Type      | Description                              
 `read_buffer_size`       | `string`  | Size of the read buffer the gRPC server will use for reading from clients. | `"512KiB"`        | no
 `write_buffer_size`      | `string`  | Size of the write buffer the gRPC server will use for writing to clients.  |                   | no
 `include_metadata`       | `boolean` | Propagate incoming connection metadata to downstream consumers.            |                   | no
+`auth`              | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.     |               | no
 
 ### tls block
 
@@ -154,6 +155,7 @@ Name                     | Type      | Description                              
 `max_request_body_size`  | `string`  | Maximum request body size the server will allow.                | `20MiB`           | no
 `include_metadata`       | `boolean` | Propagate incoming connection metadata to downstream consumers. |                   | no
 `compression_algorithms` | `list(string)` | A list of compression algorithms the server can accept.    | `["", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"]` | no
+`auth`              | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.     |               | no
 
 ### cors block
 
@@ -261,6 +263,28 @@ otelcol.exporter.otlp "default" {
 ## Technical details
 
 `otelcol.receiver.jaeger` supports [Gzip](https://en.wikipedia.org/wiki/Gzip) for compression.
+
+## Enabling Authentication
+
+You can create a `jaeger` receiver that requires authentication for requests. This is useful for limiting who can push data to the server. Note that not all OpenTelemetry Collector (otelcol) authentication plugins support receiver authentication. Please refer to the documentation for each `otelcol.auth.*` plugin to determine its compatibility. This functionality is currently limited to the GRPC/HTTP blocks.
+
+```alloy
+otelcol.receiver.jaeger "default" {
+  protocols {
+    grpc {
+      auth = otelcol.auth.basic.creds.handler
+    }
+    thrift_http {
+      auth = otelcol.auth.basic.creds.handler
+    }
+  }
+}
+
+otelcol.auth.basic "creds" {
+    username = sys.env("USERNAME")
+    password = sys.env("PASSWORD")
+}
+```
 
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.opencensus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.opencensus.md
@@ -51,6 +51,7 @@ Name | Type | Description | Default | Required
 `cors_allowed_origins` are the allowed [CORS](https://github.com/rs/cors) origins for HTTP/JSON requests.
 An empty list means that CORS is not enabled at all. A wildcard (*) can be
 used to match any origin or one or more characters of an origin.
+`auth`              | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.     |               | no
 
 The "endpoint" parameter is the same for both gRPC and HTTP/JSON, as the protocol is recognized and processed accordingly.
 
@@ -205,6 +206,21 @@ otelcol.exporter.otlp "default" {
     client {
         endpoint = sys.env("OTLP_ENDPOINT")
     }
+}
+```
+
+## Enabling Authentication
+
+You can create a `opencensus` receiver that requires authentication for requests. This is useful for limiting who can push data to the server. Note that not all OpenTelemetry Collector (otelcol) authentication plugins support receiver authentication. Please refer to the documentation for each `otelcol.auth.*` plugin to determine its compatibility.
+
+```alloy
+otelcol.receiver.opencensus "default" {
+  auth = otelcol.auth.basic.creds.handler
+}
+
+otelcol.auth.basic "creds" {
+    username = sys.env("USERNAME")
+    password = sys.env("PASSWORD")
 }
 ```
 <!-- START GENERATED COMPATIBLE COMPONENTS -->

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.opencensus.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.opencensus.md
@@ -47,11 +47,12 @@ Name | Type | Description | Default | Required
 `read_buffer_size` | `string` | Size of the read buffer the gRPC server will use for reading from clients. | `"512KiB"` | no
 `write_buffer_size` | `string` | Size of the write buffer the gRPC server will use for writing to clients. | | no
 `include_metadata` | `boolean` | Propagate incoming connection metadata to downstream consumers. | | no
+`auth`              | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.     |               | no
 
 `cors_allowed_origins` are the allowed [CORS](https://github.com/rs/cors) origins for HTTP/JSON requests.
 An empty list means that CORS is not enabled at all. A wildcard (*) can be
 used to match any origin or one or more characters of an origin.
-`auth`              | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.     |               | no
+
 
 The "endpoint" parameter is the same for both gRPC and HTTP/JSON, as the protocol is recognized and processed accordingly.
 

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.otlp.md
@@ -85,6 +85,7 @@ Name | Type | Description | Default | Required
 `read_buffer_size` | `string` | Size of the read buffer the gRPC server will use for reading from clients. | `"512KiB"` | no
 `write_buffer_size` | `string` | Size of the write buffer the gRPC server will use for writing to clients. | | no
 `include_metadata` | `boolean` | Propagate incoming connection metadata to downstream consumers. | | no
+`auth`              | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.     |               | no
 
 ### tls block
 
@@ -145,6 +146,7 @@ Name | Type | Description | Default         | Required
 `metrics_url_path` | `string` | The URL path to receive metrics on. | `"/v1/metrics"` | no
 `logs_url_path` | `string` | The URL path to receive logs on. | `"/v1/logs"`    | no
 `compression_algorithms` | `list(string)` | A list of compression algorithms the server can accept.    | `["", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"]` | no
+`auth`              | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.     |               | no
 
 To send telemetry signals to `otelcol.receiver.otlp` with HTTP/JSON, POST to:
 * `[endpoint][traces_url_path]` for traces.
@@ -240,6 +242,30 @@ otelcol.exporter.otlp "default" {
 ## Technical details
 
 `otelcol.receiver.otlp` supports [gzip](https://en.wikipedia.org/wiki/Gzip) for compression.
+
+## Enabling Authentication
+
+You can create a `otlp` receiver that requires authentication for requests. This is useful for limiting who can push data to the server. Note that not all OpenTelemetry Collector (otelcol) authentication plugins support receiver authentication. Please refer to the documentation for each `otelcol.auth.*` plugin to determine its compatibility.
+
+```alloy
+otelcol.receiver.otlp "default" {
+  http {
+    auth = otelcol.auth.basic.creds.handler
+  }
+  grpc {
+     auth = otelcol.auth.basic.creds.handler
+  }
+
+  output {
+   ...
+  }
+}
+
+otelcol.auth.basic "creds" {
+    username = sys.env("USERNAME")
+    password = sys.env("PASSWORD")
+}
+```
 <!-- START GENERATED COMPATIBLE COMPONENTS -->
 
 ## Compatible components

--- a/docs/sources/reference/components/otelcol/otelcol.receiver.zipkin.md
+++ b/docs/sources/reference/components/otelcol/otelcol.receiver.zipkin.md
@@ -39,6 +39,7 @@ Name | Type | Description | Default | Required
 `max_request_body_size` | `string`   | Maximum request body size the server will allow.                   | `20MiB`          | no
 `include_metadata` | `boolean` | Propagate incoming connection metadata to downstream consumers. | | no
 `compression_algorithms` | `list(string)` | A list of compression algorithms the server can accept.    | `["", "gzip", "zstd", "zlib", "snappy", "deflate", "lz4"]` | no
+`auth`              | `capsule(otelcol.Handler)` | Handler from an `otelcol.auth` component to use for authenticating requests.     |               | no
 
 If `parse_string_tags` is `true`, string tags and binary annotations are
 converted to `int`, `bool`, and `float` if possible. String tags and binary
@@ -139,6 +140,21 @@ otelcol.exporter.otlp "default" {
   client {
     endpoint = sys.env("OTLP_ENDPOINT")
   }
+}
+```
+
+## Enabling Authentication
+
+You can create a `zipkin` receiver that requires authentication for requests. This is useful for limiting who can push data to the server. Note that not all OpenTelemetry Collector (otelcol) authentication plugins support receiver authentication. Please refer to the documentation for each `otelcol.auth.*` plugin to determine its compatibility.
+
+```alloy
+otelcol.receiver.zipkin "default" {
+  auth = otelcol.auth.basic.creds.handler
+}
+
+otelcol.auth.basic "creds" {
+    username = sys.env("USERNAME")
+    password = sys.env("PASSWORD")
 }
 ```
 <!-- START GENERATED COMPATIBLE COMPONENTS -->

--- a/internal/component/faro/receiver/receiver_otelcol_test.go
+++ b/internal/component/faro/receiver/receiver_otelcol_test.go
@@ -1,4 +1,4 @@
-// //go:build !race
+//go:build !race
 
 package receiver
 

--- a/internal/component/faro/receiver/receiver_otelcol_test.go
+++ b/internal/component/faro/receiver/receiver_otelcol_test.go
@@ -1,4 +1,4 @@
-//go:build !race
+// //go:build !race
 
 package receiver
 
@@ -78,7 +78,7 @@ func TestWithOtelcolConsumer(t *testing.T) {
 		err := otelcolExporter.Run(ctx, otlphttp.Arguments{
 			Client: otlphttp.HTTPClientArguments(otelcol.HTTPClientArguments{
 				Endpoint: finalOtelServer.URL,
-				Auth:     &otelcolAuthHeaderExport.Handler,
+				Auth:     otelcolAuthHeaderExport.Handler,
 				TLS: otelcol.TLSClientArguments{
 					Insecure:           true,
 					InsecureSkipVerify: true,

--- a/internal/component/otelcol/auth/auth.go
+++ b/internal/component/otelcol/auth/auth.go
@@ -34,12 +34,16 @@ import (
 var (
 	ErrNotServerExtension = errors.New("component does not support server authentication")
 	ErrNotClientExtension = errors.New("component does not support client authentication")
-	ErrInvalidExtension   = errors.New("invalid extension")
 )
 
 type ExtensionType string
+type AuthFeature byte
 
 const (
+	ClientAuthSupported          AuthFeature = 1 << iota
+	ServerAuthSupported          AuthFeature = 1 << iota
+	ClientAndServerAuthSupported AuthFeature = ClientAuthSupported | ServerAuthSupported
+
 	Server ExtensionType = "server"
 	Client ExtensionType = "client"
 )
@@ -49,12 +53,18 @@ const (
 type Arguments interface {
 	component.Arguments
 
+	// AuthFeature returns the type of auth that a opentelemetry collector plugin supports
+	// client auth, server auth or both.
+	AuthFeatures() AuthFeature
+
 	// ConvertClient converts the Arguments into an OpenTelemetry Collector
-	// client authentication extension configuration.
+	// client authentication extension configuration. If the plugin does
+	// not support server authentication it should return nil, nil
 	ConvertClient() (otelcomponent.Config, error)
 
 	// ConvetServer converts the Arguments into an OpenTelemetry Collector
-	// server authentication extension configuration
+	// server authentication extension configuration. If the plugin does
+	// not support server authentication it should return nil, nil
 	ConvertServer() (otelcomponent.Config, error)
 
 	// Extensions returns the set of extensions that the configured component is
@@ -83,6 +93,8 @@ type Handler struct {
 	handlerMap  map[ExtensionType]*ExtensionHandler
 }
 
+// NewHandler creates a handler that can be exported
+// in a capsule for otel servers to consume.
 func NewHandler(componentID string) *Handler {
 	return &Handler{
 		componentID: componentID,
@@ -90,12 +102,20 @@ func NewHandler(componentID string) *Handler {
 	}
 }
 
+// GetExtension retrieves the extension for the requested auth type, server or client.
 func (h *Handler) GetExtension(et ExtensionType) (*ExtensionHandler, error) {
 	ext, ok := h.handlerMap[et]
+
+	// This condition shouldn't happen since both extension types are set in Update(), but
+	// this will prevent a panic if it is somehow unset.
 	if !ok {
-		return nil, fmt.Errorf("error initializing %s auth extension. component %s was unexpectedly nil", et, h.componentID)
+		return nil, fmt.Errorf("error getting %s auth extension. component %s was unexpectedly nil", et, h.componentID)
 	}
 
+	// Check to make sure the extension does not have Error set.
+	// see SetupExtension() to see how this value is set.
+	// In general the error value is set if an auth extension
+	// does not support the type of authentication that was requested.
 	if ext.Error != nil {
 		return nil, ext.Error
 	}
@@ -103,9 +123,16 @@ func (h *Handler) GetExtension(et ExtensionType) (*ExtensionHandler, error) {
 	return ext, nil
 }
 
+// AddExtension registers an extension type with the handler so it can be referenced
+// by another component.
 func (h *Handler) AddExtension(et ExtensionType, eh *ExtensionHandler) error {
+	// If an invalid extension is passed raise an error.
 	if et != Server && et != Client {
 		return fmt.Errorf("invalid extension type %s", et)
+	}
+
+	if eh == nil {
+		return fmt.Errorf("extension handler must not be null")
 	}
 
 	h.handlerMap[et] = eh
@@ -115,6 +142,7 @@ func (h *Handler) AddExtension(et ExtensionType, eh *ExtensionHandler) error {
 type ExtensionHandler struct {
 	ID        otelcomponent.ID
 	Extension otelextension.Extension
+
 	// Set if the extension does not support the type of authentication
 	// requested
 	Error error
@@ -229,29 +257,38 @@ func (a *Auth) Update(args component.Arguments) error {
 
 	// Create instances of the extension from our factory.
 	var components []otelcomponent.Component
+
+	// Make sure the component returned a valid set of auth flags.
+	authFeature := rargs.AuthFeatures()
+	if valid := ValidateAuthFeatures(authFeature); !valid {
+		return fmt.Errorf("invalid auth flag %d returned by component %s", authFeature, a.opts.ID)
+	}
+
+	// Registers the client extension for the otel collector plugin
 	handler := NewHandler(a.opts.ID)
-	clientEh, err := a.setupExtension(Client, rargs, settings)
+	clientEh, err := a.SetupExtension(Client, rargs, settings)
 	if err != nil {
 		return err
 	}
 
-	// Extension could be nil if the auth plugin does not support client auth
-	if clientEh.Extension != nil {
+	// If the extension supports client auth schedule it.
+	if HasAuthFeature(authFeature, ClientAuthSupported) {
 		components = append(components, clientEh.Extension)
 	}
 
-	// Register extension so it can be retrieved
+	// Register extension so it can be retrieved when referenced.
 	if err := handler.AddExtension(Client, clientEh); err != nil {
 		return err
 	}
 
-	serverEh, err := a.setupExtension(Server, rargs, settings)
+	// Registers server authentication plugin.
+	serverEh, err := a.SetupExtension(Server, rargs, settings)
 	if err != nil {
 		return err
 	}
 
-	// Extension could be nil if the auth plugin does not support server auth.
-	if serverEh.Extension != nil {
+	// If the extension supports server auth schedule it.
+	if HasAuthFeature(authFeature, ServerAuthSupported) {
 		components = append(components, serverEh.Extension)
 	}
 
@@ -292,37 +329,54 @@ func NormalizeType(in string) string {
 	return res
 }
 
-func (a *Auth) setupExtension(t ExtensionType, rargs Arguments, settings otelextension.Settings) (*ExtensionHandler, error) {
+// SetupExtension sets up the extension handler object with the appropriate fields to map the alloy
+// capsule to the underlying otel auth extension.
+func (a *Auth) SetupExtension(t ExtensionType, rargs Arguments, settings otelextension.Settings) (*ExtensionHandler, error) {
 	var otelConfig otelcomponent.Config
 	var err error
 	var notSupportedErr error
+	var requiredAuthFeature AuthFeature
+
+	// Retrieve the appropriate auth extension for the requested type.
 	if t == Server {
 		otelConfig, err = rargs.ConvertServer()
 		notSupportedErr = ErrNotServerExtension
+		requiredAuthFeature = ServerAuthSupported
 	}
 	if t == Client {
 		otelConfig, err = rargs.ConvertClient()
 		notSupportedErr = ErrNotClientExtension
+		requiredAuthFeature = ClientAuthSupported
 	}
 
+	// If there was an error converting the server/client args fail now.
 	if err != nil {
 		return nil, err
 	}
 
 	eh := &ExtensionHandler{}
+	extensionAuthFeatures := rargs.AuthFeatures()
 
-	// Auth plugins that don't support the client/server auth
-	// are expected to return nil, check for that error here.
-	if otelConfig == nil {
+	// Auth plugins return a feature flag indicating the types of authentication they support.
+	// If the plugin does not support the requested extension type (client or server authentication),
+	// the handler will set the error field. This results in an error being triggered if the unsupported
+	// extension is accessed via the handler. However, we do not return an error immediately because
+	// the user must explicitly request the invalid handler in their configuration for the error to occur.
+	// Refer to Handler.GetExtension() for the implementation logic.
+	if !HasAuthFeature(extensionAuthFeatures, requiredAuthFeature) {
 		eh.Error = fmt.Errorf("%s %w", a.opts.ID, notSupportedErr)
 		return eh, nil
 	}
 
+	// Create the otel extension via its factory.
 	otelExtension, err := a.createExtension(otelConfig, settings)
 	if err != nil {
 		return nil, err
 	}
 
+	// Create an extension id based off the alloy name. For example
+	// auth.basic.creds will become auth.basic.creds.server/client depending on
+	// the type.
 	cTypeStr := NormalizeType(fmt.Sprintf("%s.%s", a.opts.ID, t))
 	eh.ID = otelcomponent.NewID(otelcomponent.MustNewType(cTypeStr))
 	eh.Extension = otelExtension
@@ -330,14 +384,31 @@ func (a *Auth) setupExtension(t ExtensionType, rargs Arguments, settings otelext
 	return eh, nil
 }
 
+// createExtension uses the otelextension factory to construct the otel auth extension.
 func (a *Auth) createExtension(config otelcomponent.Config, settings otelextension.Settings) (otelcomponent.Component, error) {
 	ext, err := a.factory.Create(a.ctx, settings, config)
 	if err != nil {
 		return nil, err
 	}
+
+	// sanity check
 	if ext == nil {
 		return nil, fmt.Errorf("extension was not created")
 	}
 
 	return ext, nil
+}
+
+// ValidateAuthFeatures makes sure a valid auth feature was returned by a
+func ValidateAuthFeatures(f AuthFeature) bool {
+	validFlags := ClientAuthSupported | ServerAuthSupported | ClientAndServerAuthSupported
+
+	// bit clear any flags not set in f.
+	// if this is not zero then an invalid flag was passed.
+	return f&^validFlags == 0
+}
+
+func HasAuthFeature(flag AuthFeature, feature AuthFeature) bool {
+	// bitwise and the two features together. If not zero it has the feature
+	return flag&feature != 0
 }

--- a/internal/component/otelcol/auth/auth_test.go
+++ b/internal/component/otelcol/auth/auth_test.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/grafana/alloy/internal/component"
-	"github.com/grafana/alloy/internal/component/otelcol"
 	"github.com/grafana/alloy/internal/component/otelcol/auth"
 	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
 	"github.com/grafana/alloy/internal/runtime/componenttest"
 	"github.com/grafana/alloy/internal/util"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	otelcomponent "go.opentelemetry.io/collector/component"
 	otelextension "go.opentelemetry.io/collector/extension"
@@ -26,10 +26,13 @@ func TestAuth(t *testing.T) {
 		}
 	)
 
+	fakeAuthArgs := &fakeAuthArgs{}
+	fakeAuthArgs.On("AuthFeatures").Return(auth.ClientAndServerAuthSupported)
+
 	// Create and start our Alloy component. We then wait for it to export a
 	// consumer that we can send data to.
 	te := newTestEnvironment(t, onCreated)
-	te.Start(fakeAuthArgs{})
+	te.Start(fakeAuthArgs)
 
 	require.NoError(t, waitCreated.Wait(time.Second), "extension never created")
 }
@@ -46,7 +49,7 @@ func newTestEnvironment(t *testing.T, onCreated func()) *testEnvironment {
 	reg := component.Registration{
 		Name:    "testcomponent",
 		Args:    fakeAuthArgs{},
-		Exports: otelcol.ConsumerExports{},
+		Exports: auth.Exports{},
 		Build: func(opts component.Options, args component.Arguments) (component.Component, error) {
 			factory := otelextension.NewFactory(
 				otelcomponent.MustNewType("testcomponent"),
@@ -58,7 +61,7 @@ func newTestEnvironment(t *testing.T, onCreated func()) *testEnvironment {
 				) (otelcomponent.Component, error) {
 
 					onCreated()
-					return nil, nil
+					return fakeOtelComponent{}, nil
 				}, otelcomponent.StabilityLevelUndefined,
 			)
 
@@ -80,28 +83,41 @@ func (te *testEnvironment) Start(args component.Arguments) {
 	}()
 }
 
-type fakeAuthArgs struct {
+type fakeOtelComponent struct {
 }
 
-var _ auth.Arguments = fakeAuthArgs{}
-
-func (fa fakeAuthArgs) ConvertClient() (otelcomponent.Config, error) {
-	return &struct{}{}, nil
-}
-
-func (fa fakeAuthArgs) ConvertServer() (otelcomponent.Config, error) {
-	return &struct{}{}, nil
-}
-
-func (fa fakeAuthArgs) AuthFeatures() auth.AuthFeature {
-	return auth.ClientAndServerAuthSupported
-}
-
-func (fa fakeAuthArgs) Extensions() map[otelcomponent.ID]otelextension.Extension {
+func (f fakeOtelComponent) Start(ctx context.Context, host otelcomponent.Host) error {
 	return nil
 }
 
-func (fa fakeAuthArgs) Exporters() map[pipeline.Signal]map[otelcomponent.ID]otelcomponent.Component {
+func (f fakeOtelComponent) Shutdown(ctx context.Context) error {
+	return nil
+}
+
+type fakeAuthArgs struct {
+	mock.Mock
+}
+
+var _ auth.Arguments = &fakeAuthArgs{}
+
+func (fa *fakeAuthArgs) ConvertClient() (otelcomponent.Config, error) {
+	return &struct{}{}, nil
+}
+
+func (fa *fakeAuthArgs) ConvertServer() (otelcomponent.Config, error) {
+	return &struct{}{}, nil
+}
+
+func (fa *fakeAuthArgs) AuthFeatures() auth.AuthFeature {
+	result := fa.Called()
+	return result.Get(0).(auth.AuthFeature)
+}
+
+func (fa *fakeAuthArgs) Extensions() map[otelcomponent.ID]otelextension.Extension {
+	return nil
+}
+
+func (fa *fakeAuthArgs) Exporters() map[pipeline.Signal]map[otelcomponent.ID]otelcomponent.Component {
 	return nil
 }
 
@@ -134,7 +150,7 @@ func TestNormalizeType(t *testing.T) {
 	}
 }
 
-func (fe fakeAuthArgs) DebugMetricsConfig() otelcolCfg.DebugMetricsArguments {
+func (fe *fakeAuthArgs) DebugMetricsConfig() otelcolCfg.DebugMetricsArguments {
 	var dma otelcolCfg.DebugMetricsArguments
 	dma.SetToDefault()
 	return dma
@@ -184,5 +200,98 @@ func TestHasAuthFeature(t *testing.T) {
 	for _, tc := range testcases {
 		actual := auth.HasAuthFeature(tc.input.flag, tc.input.feature)
 		require.Equal(t, tc.expected, actual, "flag:", tc.input.flag, "feature:", tc.input.feature)
+	}
+}
+
+// TestAuthHandler runs a simple functional test by running the component
+// against a mock auth extension. It validates the component starts correctly
+// and when the handler requests either a server or client handler the correct output
+// is returned
+func TestAuthHandler(t *testing.T) {
+	var (
+		waitCreated = util.NewWaitTrigger()
+		onCreated   = func() {
+			waitCreated.Trigger()
+		}
+	)
+
+	// Test case definition
+	type input struct {
+		support auth.AuthFeature
+	}
+
+	type expected struct {
+		clientAuthSupported bool
+		serverAuthSupported bool
+		err                 error
+	}
+	type tc struct {
+		input    input
+		expected expected
+	}
+
+	// Test cases
+	tcs := []tc{
+		// Validates
+		{
+			input: input{support: auth.ClientAuthSupported}, expected: expected{
+				clientAuthSupported: true, serverAuthSupported: false, err: auth.ErrNotServerExtension,
+			},
+		},
+		{
+			input: input{support: auth.ServerAuthSupported}, expected: expected{
+				clientAuthSupported: false, serverAuthSupported: true, err: auth.ErrNotClientExtension,
+			},
+		},
+		{
+			input: input{support: auth.ClientAndServerAuthSupported}, expected: expected{
+				clientAuthSupported: true, serverAuthSupported: true, err: nil,
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		// Spin up a test component
+		te := newTestEnvironment(t, onCreated)
+
+		// Mock the return of AuthFeatures to avoid creating test-specific implementations
+		// for each combination of authentication extensions supported by the OpenTelemetry collector.
+		fakeAuthArgs := &fakeAuthArgs{}
+		fakeAuthArgs.On("AuthFeatures").Return(tc.input.support)
+
+		// Start the test environment and validate it comes up properly.
+		te.Start(fakeAuthArgs)
+		require.NoError(t, waitCreated.Wait(time.Second), "extension never created")
+		require.NoError(t, te.Controller.WaitRunning(time.Second), "extension never started running")
+		require.NoError(t, te.Controller.WaitExports(time.Second), "extension never exported anything")
+
+		// Retrieve the exports of the component, make sure it exported a handler.
+		export := te.Controller.Exports()
+		authExport, ok := export.(auth.Exports)
+		require.True(t, ok, "auth component didn't export an auth export type")
+		require.NotNil(t, authExport.Handler)
+
+		// Check the state of the handler and verify it is correct.
+		clientEh, err := authExport.Handler.GetExtension(auth.Client)
+		validateHandler(t, clientEh, tc.expected.clientAuthSupported, err, tc.expected.err)
+
+		serverEh, err := authExport.Handler.GetExtension(auth.Server)
+		validateHandler(t, serverEh, tc.expected.serverAuthSupported, err, tc.expected.err)
+	}
+}
+
+// validateHandler determines what the correct state of the extension handler should be depending
+// on the test case state. If the extension supports the authentication requested it should return
+// the extension. Otherwise it should return an error saying the extension does not support the requested
+// type of authenticaiton.
+func validateHandler(t *testing.T, eh *auth.ExtensionHandler, authSupported bool, actualErr error, expectedError error) {
+	t.Helper()
+	if authSupported {
+		require.NoError(t, actualErr)
+		require.NotNil(t, eh.Extension)
+		require.NotNil(t, eh.ID)
+	} else {
+		require.NotNil(t, actualErr)
+		require.ErrorIs(t, actualErr, expectedError)
 	}
 }

--- a/internal/component/otelcol/auth/auth_test.go
+++ b/internal/component/otelcol/auth/auth_test.go
@@ -85,7 +85,11 @@ type fakeAuthArgs struct {
 
 var _ auth.Arguments = fakeAuthArgs{}
 
-func (fa fakeAuthArgs) Convert() (otelcomponent.Config, error) {
+func (fa fakeAuthArgs) ConvertClient() (otelcomponent.Config, error) {
+	return &struct{}{}, nil
+}
+
+func (fa fakeAuthArgs) ConvertServer() (otelcomponent.Config, error) {
 	return &struct{}{}, nil
 }
 

--- a/internal/component/otelcol/auth/basic/basic.go
+++ b/internal/component/otelcol/auth/basic/basic.go
@@ -2,6 +2,8 @@
 package basic
 
 import (
+	"fmt"
+
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/otelcol/auth"
 	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
@@ -52,6 +54,9 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 		ClientAuth: &basicauthextension.ClientAuthSettings{
 			Username: args.Username,
 			Password: configopaque.String(args.Password),
+		},
+		Htpasswd: &basicauthextension.HtpasswdSettings{
+			Inline: fmt.Sprintf("%s:%s", args.Username, args.Password),
 		},
 	}, nil
 }

--- a/internal/component/otelcol/auth/basic/basic.go
+++ b/internal/component/otelcol/auth/basic/basic.go
@@ -48,13 +48,17 @@ func (args *Arguments) SetToDefault() {
 	args.DebugMetrics.SetToDefault()
 }
 
-// Convert implements auth.Arguments.
-func (args Arguments) Convert() (otelcomponent.Config, error) {
+func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	return &basicauthextension.Config{
 		ClientAuth: &basicauthextension.ClientAuthSettings{
 			Username: args.Username,
 			Password: configopaque.String(args.Password),
 		},
+	}, nil
+}
+
+func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
+	return &basicauthextension.Config{
 		Htpasswd: &basicauthextension.HtpasswdSettings{
 			Inline: fmt.Sprintf("%s:%s", args.Username, args.Password),
 		},

--- a/internal/component/otelcol/auth/basic/basic.go
+++ b/internal/component/otelcol/auth/basic/basic.go
@@ -32,8 +32,6 @@ func init() {
 
 // Arguments configures the otelcol.auth.basic component.
 type Arguments struct {
-	// TODO(rfratto): should we support htpasswd?
-
 	Username string            `alloy:"username,attr"`
 	Password alloytypes.Secret `alloy:"password,attr"`
 

--- a/internal/component/otelcol/auth/basic/basic.go
+++ b/internal/component/otelcol/auth/basic/basic.go
@@ -46,6 +46,7 @@ func (args *Arguments) SetToDefault() {
 	args.DebugMetrics.SetToDefault()
 }
 
+// ConvertClient implements auth.Arguments.
 func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	return &basicauthextension.Config{
 		ClientAuth: &basicauthextension.ClientAuthSettings{
@@ -55,6 +56,7 @@ func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	}, nil
 }
 
+// ConvertServer implements auth.Arguments.
 func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
 	return &basicauthextension.Config{
 		Htpasswd: &basicauthextension.HtpasswdSettings{
@@ -63,6 +65,7 @@ func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
 	}, nil
 }
 
+// AuthFeatures implements auth.Arguments.
 func (args Arguments) AuthFeatures() auth.AuthFeature {
 	return auth.ClientAndServerAuthSupported
 }

--- a/internal/component/otelcol/auth/basic/basic.go
+++ b/internal/component/otelcol/auth/basic/basic.go
@@ -65,6 +65,10 @@ func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
 	}, nil
 }
 
+func (args Arguments) AuthFeatures() auth.AuthFeature {
+	return auth.ClientAndServerAuthSupported
+}
+
 // Extensions implements auth.Arguments.
 func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
 	return nil

--- a/internal/component/otelcol/auth/basic/basic_test.go
+++ b/internal/component/otelcol/auth/basic/basic_test.go
@@ -3,6 +3,7 @@ package basic_test
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -18,16 +19,28 @@ import (
 	extauth "go.opentelemetry.io/collector/extension/auth"
 )
 
+const (
+	actualUsername = "foo"
+	actualPassword = "bar"
+)
+
+var (
+	cfg = fmt.Sprintf(`
+		username = "%s"
+		password = "%s"
+	`, actualUsername, actualPassword)
+)
+
 // Test performs a basic integration test which runs the otelcol.auth.basic
 // component and ensures that it can be used for authentication.
-func Test(t *testing.T) {
+func TestClientAuth(t *testing.T) {
 	// Create an HTTP server which will assert that basic auth has been injected
 	// into the request.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		username, password, ok := r.BasicAuth()
 		assert.True(t, ok, "no basic auth found")
-		assert.Equal(t, "foo", username, "basic auth username didn't match")
-		assert.Equal(t, "bar", password, "basic auth password didn't match")
+		assert.Equal(t, actualUsername, username, "basic auth username didn't match")
+		assert.Equal(t, actualPassword, password, "basic auth password didn't match")
 
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -37,23 +50,7 @@ func Test(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, time.Minute)
 	defer cancel()
 
-	l := util.TestLogger(t)
-
-	// Create and run our component
-	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.auth.basic")
-	require.NoError(t, err)
-
-	cfg := `
-		username = "foo"
-		password = "bar"
-	`
-	var args basic.Arguments
-	require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
-
-	go func() {
-		err := ctrl.Run(ctx, args)
-		require.NoError(t, err)
-	}()
+	ctrl := newTestComponent(t, ctx)
 
 	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
 	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
@@ -63,36 +60,79 @@ func Test(t *testing.T) {
 	exports := ctrl.Exports().(auth.Exports)
 	require.NotNil(t, exports.Handler)
 
-	t.Run("ClientAuth", func(t *testing.T) {
-		clientExtension, err := exports.Handler.GetExtension(auth.Client)
-		require.NoError(t, err)
-		require.NotNil(t, clientExtension)
-		clientAuth, ok := clientExtension.Extension.(extauth.Client)
-		require.True(t, ok, "handler does not implement configauth.ClientAuthenticator")
+	clientExtension, err := exports.Handler.GetExtension(auth.Client)
+	require.NoError(t, err)
+	require.NotNil(t, clientExtension)
+	clientAuth, ok := clientExtension.Extension.(extauth.Client)
+	require.True(t, ok, "handler does not implement configauth.ClientAuthenticator")
 
-		rt, err := clientAuth.RoundTripper(http.DefaultTransport)
-		require.NoError(t, err)
-		cli := &http.Client{Transport: rt}
+	rt, err := clientAuth.RoundTripper(http.DefaultTransport)
+	require.NoError(t, err)
+	cli := &http.Client{Transport: rt}
 
-		// Wait until the request finishes. We don't assert anything else here; our
-		// HTTP handler won't write the response until it ensures that the basic auth
-		// was found.
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
-		require.NoError(t, err)
-		resp, err := cli.Do(req)
-		require.NoError(t, err, "HTTP request failed")
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-	})
+	// Wait until the request finishes. We don't assert anything else here; our
+	// HTTP handler won't write the response until it ensures that the basic auth
+	// was found.
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := cli.Do(req)
+	require.NoError(t, err, "HTTP request failed")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
 
-	t.Run("ServerAuth", func(t *testing.T) {
-		serverExtension, err := exports.Handler.GetExtension(auth.Server)
-		require.NoError(t, err)
-		require.NotNil(t, serverExtension)
-		serverAuth, ok := serverExtension.Extension.(extauth.Server)
-		require.True(t, ok, "handler does not implement configauth.ServerAuthenticator")
-		b64EncodingAuth := base64.StdEncoding.EncodeToString([]byte("foo:bar"))
-		_, err = serverAuth.Authenticate(ctx, map[string][]string{"Authorization": {"Basic " + b64EncodingAuth}})
-		require.NoError(t, err)
-	})
+// TestServerAuth verifies the server auth component starts up properly and we can
+// authenticate with the provided credentials.
+func TestServerAuth(t *testing.T) {
+	ctx := componenttest.TestContext(t)
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
 
+	ctrl := newTestComponent(t, ctx)
+	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+	exports, ok := ctrl.Exports().(auth.Exports)
+	require.True(t, ok, "extension doesn't export auth exports struct")
+	require.NotNil(t, exports.Handler)
+
+	// There's a data race condition in this test that causes this test to fail.
+	// The test will pass if running without race conditions with this sleep,
+	// If race condition checks are enabled it will fail. I believe this is because
+	// the upstream starts the extension asynchronously, but the scheduler expects
+	// a component to be running once Run() returns. If you have any suggestions/ideas
+	// on how to improve this test please let me know. Otherwise I will remove this test
+	// since it will cause failures.
+	time.Sleep(time.Second)
+
+	serverAuthExtension, err := exports.Handler.GetExtension(auth.Server)
+	require.NoError(t, err)
+	require.NotNil(t, serverAuthExtension.ID)
+	require.NotNil(t, serverAuthExtension.Extension)
+
+	otelServerExtension, ok := serverAuthExtension.Extension.(extauth.Server)
+	require.True(t, ok, "extension did not implement server authentication")
+
+	b64EncodingAuth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", actualUsername, actualPassword)))
+	_, err = otelServerExtension.Authenticate(ctx, map[string][]string{"Authorization": {"Basic " + b64EncodingAuth}})
+	require.NoError(t, err)
+}
+
+// newTestComponent brings up and runs the test component.
+func newTestComponent(t *testing.T, ctx context.Context) *componenttest.Controller {
+	t.Helper()
+	l := util.TestLogger(t)
+
+	// Create and run our component
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.auth.basic")
+	require.NoError(t, err)
+
+	var args basic.Arguments
+	require.NoError(t, syntax.Unmarshal([]byte(cfg), &args))
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	return ctrl
 }

--- a/internal/component/otelcol/auth/bearer/bearer.go
+++ b/internal/component/otelcol/auth/bearer/bearer.go
@@ -58,15 +58,17 @@ func (args Arguments) convert() (otelcomponent.Config, error) {
 	}, nil
 }
 
-// Convert implements auth.Arguments.
+// ConvertClient implements auth.Arguments.
 func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	return args.convert()
 }
 
+// ConvertServer implements auth.Arguments.
 func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
 	return args.convert()
 }
 
+// AuthFeatures implements auth.Arguments.
 func (args Arguments) AuthFeatures() auth.AuthFeature {
 	return auth.ClientAndServerAuthSupported
 }

--- a/internal/component/otelcol/auth/bearer/bearer.go
+++ b/internal/component/otelcol/auth/bearer/bearer.go
@@ -67,6 +67,10 @@ func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
 	return args.convert()
 }
 
+func (args Arguments) AuthFeatures() auth.AuthFeature {
+	return auth.ClientAndServerAuthSupported
+}
+
 // Extensions implements auth.Arguments.
 func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
 	return nil

--- a/internal/component/otelcol/auth/bearer/bearer.go
+++ b/internal/component/otelcol/auth/bearer/bearer.go
@@ -51,12 +51,20 @@ func (args *Arguments) SetToDefault() {
 	args.DebugMetrics.SetToDefault()
 }
 
-// Convert implements auth.Arguments.
-func (args Arguments) Convert() (otelcomponent.Config, error) {
+func (args Arguments) convert() (otelcomponent.Config, error) {
 	return &bearertokenauthextension.Config{
 		Scheme:      args.Scheme,
 		BearerToken: configopaque.String(args.Token),
 	}, nil
+}
+
+// Convert implements auth.Arguments.
+func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
+	return args.convert()
+}
+
+func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
+	return args.convert()
 }
 
 // Extensions implements auth.Arguments.

--- a/internal/component/otelcol/auth/bearer/bearer_test.go
+++ b/internal/component/otelcol/auth/bearer/bearer_test.go
@@ -2,8 +2,10 @@ package bearer_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -19,7 +21,7 @@ import (
 
 // Test performs a basic integration test which runs the otelcol.auth.bearer
 // component and ensures that it can be used for authentication.
-func Test(t *testing.T) {
+func TestClient(t *testing.T) {
 	type TestDefinition struct {
 		testName          string
 		expectedHeaderVal string
@@ -75,22 +77,7 @@ func Test(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, time.Minute)
 		defer cancel()
 
-		l := util.TestLogger(t)
-
-		// Create and run our component
-		ctrl, err := componenttest.NewControllerFromID(l, "otelcol.auth.bearer")
-		require.NoError(t, err)
-
-		var args bearer.Arguments
-		require.NoError(t, syntax.Unmarshal([]byte(tt.alloyConfig), &args))
-
-		go func() {
-			err := ctrl.Run(ctx, args)
-			require.NoError(t, err)
-		}()
-
-		require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
-		require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+		ctrl := newTestComponent(t, ctx, tt.alloyConfig)
 
 		// Get the authentication extension from our component and use it to make a
 		// request to our test server.
@@ -116,4 +103,109 @@ func Test(t *testing.T) {
 		require.NoError(t, err, "HTTP request failed")
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	}
+}
+
+func TestServer(t *testing.T) {
+	type TestDefinition struct {
+		testName    string
+		token       string
+		scheme      string
+		alloyConfig string
+	}
+	token := "123"
+	tokenCfg := fmt.Sprintf(`token = "%s"`, token)
+	tests := []TestDefinition{
+		{
+			testName: "Test1",
+			token:    token,
+			scheme:   "Bearer",
+			alloyConfig: fmt.Sprintf(`
+			%s
+			`, tokenCfg),
+		},
+		{
+			testName: "Test2",
+			token:    token,
+			scheme:   "Bearer",
+			alloyConfig: fmt.Sprintf(`
+			%s
+			scheme = "Bearer"
+			`, tokenCfg),
+		},
+		{
+			testName: "Test3",
+			token:    token,
+			scheme:   "MyScheme",
+			alloyConfig: fmt.Sprintf(`
+			%s
+			scheme = "MyScheme"
+			`, tokenCfg),
+		},
+		{
+			testName: "Test4",
+			token:    token,
+			scheme:   "",
+			alloyConfig: fmt.Sprintf(`
+			%s
+			scheme = ""
+			`, tokenCfg),
+		},
+	}
+
+	for _, td := range tests {
+		ctx := componenttest.TestContext(t)
+		ctx, cancel := context.WithTimeout(ctx, time.Minute)
+		defer cancel()
+
+		// Spin up component
+		ctrl := newTestComponent(t, ctx, td.alloyConfig)
+		exports := ctrl.Exports()
+		require.NotNil(t, exports)
+
+		authExport, ok := exports.(auth.Exports)
+		require.True(t, ok, "component doesn't export auth export struct")
+
+		// Get handler from exports
+		handler := authExport.Handler
+		require.NotNil(t, handler)
+
+		// Get the server auth extension
+		serverExtension, err := handler.GetExtension(auth.Server)
+		require.NoError(t, err)
+		require.NotNil(t, serverExtension.Extension)
+		require.NotNil(t, serverExtension.ID)
+
+		// Convert to server auth extension
+		otelServerAuthExtension, ok := serverExtension.Extension.(extauth.Server)
+		require.True(t, ok, "extension does not implement server authentication")
+
+		scheme := fmt.Sprintf("%s %s", td.scheme, td.token)
+
+		// Trim the space in case bearer token is set to an empty string
+		scheme = strings.TrimSpace(scheme)
+		_, err = otelServerAuthExtension.Authenticate(ctx, map[string][]string{"Authorization": {scheme}})
+		require.NoError(t, err, td.testName)
+	}
+}
+
+func newTestComponent(t *testing.T, ctx context.Context, alloyConfig string) *componenttest.Controller {
+	t.Helper()
+	l := util.TestLogger(t)
+
+	// Create and run our component
+	ctrl, err := componenttest.NewControllerFromID(l, "otelcol.auth.bearer")
+	require.NoError(t, err)
+
+	var args bearer.Arguments
+	require.NoError(t, syntax.Unmarshal([]byte(alloyConfig), &args))
+
+	go func() {
+		err := ctrl.Run(ctx, args)
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, ctrl.WaitRunning(time.Second), "component never started")
+	require.NoError(t, ctrl.WaitExports(time.Second), "component never exported anything")
+
+	return ctrl
 }

--- a/internal/component/otelcol/auth/bearer/bearer_test.go
+++ b/internal/component/otelcol/auth/bearer/bearer_test.go
@@ -95,9 +95,12 @@ func Test(t *testing.T) {
 		// Get the authentication extension from our component and use it to make a
 		// request to our test server.
 		exports := ctrl.Exports().(auth.Exports)
-		require.NotNil(t, exports.Handler.Extension, "handler extension is nil")
+		require.NotNil(t, exports.Handler, "handler extension is nil")
 
-		clientAuth, ok := exports.Handler.Extension.(extauth.Client)
+		clientExtension, err := exports.Handler.GetExtension(auth.Client)
+		require.NoError(t, err)
+
+		clientAuth, ok := clientExtension.Extension.(extauth.Client)
 		require.True(t, ok, "handler does not implement configauth.ClientAuthenticator")
 
 		rt, err := clientAuth.RoundTripper(http.DefaultTransport)

--- a/internal/component/otelcol/auth/headers/headers.go
+++ b/internal/component/otelcol/auth/headers/headers.go
@@ -47,7 +47,7 @@ func (args *Arguments) SetToDefault() {
 	args.DebugMetrics.SetToDefault()
 }
 
-// Convert implements auth.Arguments.
+// ConvertClient implements auth.Arguments.
 func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	var upstreamHeaders []headerssetterextension.HeaderConfig
 	for _, h := range args.Headers {
@@ -86,6 +86,7 @@ func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension 
 	return nil
 }
 
+// AuthFeatures implements auth.Arguments.
 func (args Arguments) AuthFeatures() auth.AuthFeature {
 	return auth.ClientAuthSupported
 }

--- a/internal/component/otelcol/auth/headers/headers.go
+++ b/internal/component/otelcol/auth/headers/headers.go
@@ -1,4 +1,4 @@
-// // Package headers provides an otelcol.auth.headers component.
+// Package headers provides an otelcol.auth.headers component.
 package headers
 
 import (

--- a/internal/component/otelcol/auth/headers/headers.go
+++ b/internal/component/otelcol/auth/headers/headers.go
@@ -86,6 +86,10 @@ func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension 
 	return nil
 }
 
+func (args Arguments) AuthFeatures() auth.AuthFeature {
+	return auth.ClientAuthSupported
+}
+
 // Exporters implements auth.Arguments.
 func (args Arguments) Exporters() map[pipeline.Signal]map[otelcomponent.ID]otelcomponent.Component {
 	return nil

--- a/internal/component/otelcol/auth/headers/headers.go
+++ b/internal/component/otelcol/auth/headers/headers.go
@@ -76,8 +76,9 @@ func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	}, nil
 }
 
+// ConvertServer returns nil since theheaders extension does not support server authenticaiton.
 func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
-	return nil, fmt.Errorf("%w, headers extension does not implement server authentication", auth.ErrNotServerExtension)
+	return nil, nil
 }
 
 // Extensions implements auth.Arguments.

--- a/internal/component/otelcol/auth/headers/headers.go
+++ b/internal/component/otelcol/auth/headers/headers.go
@@ -1,4 +1,4 @@
-// Package headers provides an otelcol.auth.headers component.
+// // Package headers provides an otelcol.auth.headers component.
 package headers
 
 import (
@@ -48,7 +48,7 @@ func (args *Arguments) SetToDefault() {
 }
 
 // Convert implements auth.Arguments.
-func (args Arguments) Convert() (otelcomponent.Config, error) {
+func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	var upstreamHeaders []headerssetterextension.HeaderConfig
 	for _, h := range args.Headers {
 		upstreamHeader := headerssetterextension.HeaderConfig{
@@ -70,9 +70,14 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 		upstreamHeaders = append(upstreamHeaders, upstreamHeader)
 	}
 
+	// OtelExtensionConfig does not implement ServerAuth
 	return &headerssetterextension.Config{
 		HeadersConfig: upstreamHeaders,
 	}, nil
+}
+
+func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
+	return nil, fmt.Errorf("%w, headers extension does not implement server authentication", auth.ErrNotServerExtension)
 }
 
 // Extensions implements auth.Arguments.

--- a/internal/component/otelcol/auth/headers/headers_test.go
+++ b/internal/component/otelcol/auth/headers/headers_test.go
@@ -61,9 +61,12 @@ func Test(t *testing.T) {
 	// Get the authentication extension from our component and use it to make a
 	// request to our test server.
 	exports := ctrl.Exports().(auth.Exports)
-	require.NotNil(t, exports.Handler.Extension, "handler extension is nil")
 
-	clientAuth, ok := exports.Handler.Extension.(extauth.Client)
+	ext, err := exports.Handler.GetExtension(auth.Client)
+	require.NoError(t, err)
+	require.NotNil(t, ext.Extension, "handler extension is nil")
+
+	clientAuth, ok := ext.Extension.(extauth.Client)
 	require.True(t, ok, "handler does not implement configauth.ClientAuthenticator")
 
 	rt, err := clientAuth.RoundTripper(http.DefaultTransport)
@@ -169,7 +172,7 @@ func TestArguments_UnmarshalAlloy(t *testing.T) {
 		}
 		require.NoError(t, err)
 
-		ext, err := args.Convert()
+		ext, err := args.ConvertClient()
 
 		require.NoError(t, err)
 		otelArgs, ok := (ext).(*headerssetterextension.Config)

--- a/internal/component/otelcol/auth/oauth2/oauth2.go
+++ b/internal/component/otelcol/auth/oauth2/oauth2.go
@@ -1,7 +1,6 @@
 package oauth2
 
 import (
-	"fmt"
 	"net/url"
 	"time"
 
@@ -69,8 +68,9 @@ func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	}, nil
 }
 
+// ConvertServer returns nil since the ouath2 client extension doesn ot support serve auth
 func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
-	return nil, fmt.Errorf("%w oauth2 client extension does not implement server authentication", auth.ErrNotServerExtension)
+	return nil, nil
 }
 
 // Extensions implements auth.Arguments.

--- a/internal/component/otelcol/auth/oauth2/oauth2.go
+++ b/internal/component/otelcol/auth/oauth2/oauth2.go
@@ -83,6 +83,10 @@ func (args Arguments) Exporters() map[pipeline.Signal]map[otelcomponent.ID]otelc
 	return nil
 }
 
+func (args Arguments) AuthFeatures() auth.AuthFeature {
+	return auth.ClientAuthSupported
+}
+
 // DebugMetricsConfig implements auth.Arguments.
 func (args Arguments) DebugMetricsConfig() otelcolCfg.DebugMetricsArguments {
 	return args.DebugMetrics

--- a/internal/component/otelcol/auth/oauth2/oauth2.go
+++ b/internal/component/otelcol/auth/oauth2/oauth2.go
@@ -53,7 +53,7 @@ func (args *Arguments) SetToDefault() {
 	args.DebugMetrics.SetToDefault()
 }
 
-// Convert implements auth.Arguments.
+// ConvertClient implements auth.Arguments.
 func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	return &oauth2clientauthextension.Config{
 		ClientID:         args.ClientID,
@@ -68,7 +68,7 @@ func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	}, nil
 }
 
-// ConvertServer returns nil since the ouath2 client extension doesn ot support serve auth
+// ConvertServer returns nil since the ouath2 client extension does not support server auth.
 func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
 	return nil, nil
 }
@@ -83,6 +83,7 @@ func (args Arguments) Exporters() map[pipeline.Signal]map[otelcomponent.ID]otelc
 	return nil
 }
 
+// AuthFeatures implements auth.Arguments.
 func (args Arguments) AuthFeatures() auth.AuthFeature {
 	return auth.ClientAuthSupported
 }

--- a/internal/component/otelcol/auth/oauth2/oauth2.go
+++ b/internal/component/otelcol/auth/oauth2/oauth2.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"fmt"
 	"net/url"
 	"time"
 
@@ -54,7 +55,7 @@ func (args *Arguments) SetToDefault() {
 }
 
 // Convert implements auth.Arguments.
-func (args Arguments) Convert() (otelcomponent.Config, error) {
+func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	return &oauth2clientauthextension.Config{
 		ClientID:         args.ClientID,
 		ClientIDFile:     args.ClientIDFile,
@@ -66,6 +67,10 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 		TLSSetting:       *args.TLSSetting.Convert(),
 		Timeout:          args.Timeout,
 	}, nil
+}
+
+func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
+	return nil, fmt.Errorf("%w oauth2 client extension does not implement server authentication", auth.ErrNotServerExtension)
 }
 
 // Extensions implements auth.Arguments.

--- a/internal/component/otelcol/auth/oauth2/oauth2_test.go
+++ b/internal/component/otelcol/auth/oauth2/oauth2_test.go
@@ -112,9 +112,13 @@ func Test(t *testing.T) {
 			// Get the authentication extension from our component and use it to make a
 			// request to our test server.
 			exports := ctrl.Exports().(auth.Exports)
-			require.NotNil(t, exports.Handler.Extension, "handler extension is nil")
 
-			clientAuth, ok := exports.Handler.Extension.(extauth.Client)
+			ext, err := exports.Handler.GetExtension(auth.Client)
+			require.NoError(t, err)
+
+			require.NotNil(t, ext.Extension, "handler extension is nil")
+
+			clientAuth, ok := ext.Extension.(extauth.Client)
 			require.True(t, ok, "handler does not implement configauth.ClientAuthenticator")
 
 			rt, err := clientAuth.RoundTripper(http.DefaultTransport)

--- a/internal/component/otelcol/auth/oauth2/oauth2_test.go
+++ b/internal/component/otelcol/auth/oauth2/oauth2_test.go
@@ -115,7 +115,6 @@ func Test(t *testing.T) {
 
 			ext, err := exports.Handler.GetExtension(auth.Client)
 			require.NoError(t, err)
-
 			require.NotNil(t, ext.Extension, "handler extension is nil")
 
 			clientAuth, ok := ext.Extension.(extauth.Client)

--- a/internal/component/otelcol/auth/sigv4/sigv4.go
+++ b/internal/component/otelcol/auth/sigv4/sigv4.go
@@ -1,8 +1,6 @@
 package sigv4
 
 import (
-	"fmt"
-
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/otelcol/auth"
 	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
@@ -60,8 +58,9 @@ func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	return &res, nil
 }
 
+// ConvertServer returns nil since the sigv4 extension does not support server authentication
 func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
-	return nil, fmt.Errorf("%w sigv4authplugin does not implement server authentication", auth.ErrNotServerExtension)
+	return nil, nil
 }
 
 // Validate implements syntax.Validator.

--- a/internal/component/otelcol/auth/sigv4/sigv4.go
+++ b/internal/component/otelcol/auth/sigv4/sigv4.go
@@ -74,6 +74,10 @@ func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension 
 	return nil
 }
 
+func (args Arguments) AuthFeatures() auth.AuthFeature {
+	return auth.ClientAuthSupported
+}
+
 // Exporters implements auth.Arguments.
 func (args Arguments) Exporters() map[pipeline.Signal]map[otelcomponent.ID]otelcomponent.Component {
 	return nil

--- a/internal/component/otelcol/auth/sigv4/sigv4.go
+++ b/internal/component/otelcol/auth/sigv4/sigv4.go
@@ -43,7 +43,7 @@ func (args *Arguments) SetToDefault() {
 	args.DebugMetrics.SetToDefault()
 }
 
-// Convert implements auth.Arguments.
+// ConvertClient implements auth.Arguments.
 func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	res := sigv4authextension.Config{
 		Region:     args.Region,
@@ -58,7 +58,7 @@ func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	return &res, nil
 }
 
-// ConvertServer returns nil since the sigv4 extension does not support server authentication
+// ConvertServer returns nil since the sigv4 extension does not support server authentication.
 func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
 	return nil, nil
 }
@@ -74,6 +74,7 @@ func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension 
 	return nil
 }
 
+// AuthFeatures implements auth.Arguments.
 func (args Arguments) AuthFeatures() auth.AuthFeature {
 	return auth.ClientAuthSupported
 }

--- a/internal/component/otelcol/auth/sigv4/sigv4.go
+++ b/internal/component/otelcol/auth/sigv4/sigv4.go
@@ -1,6 +1,8 @@
 package sigv4
 
 import (
+	"fmt"
+
 	"github.com/grafana/alloy/internal/component"
 	"github.com/grafana/alloy/internal/component/otelcol/auth"
 	otelcolCfg "github.com/grafana/alloy/internal/component/otelcol/config"
@@ -44,7 +46,7 @@ func (args *Arguments) SetToDefault() {
 }
 
 // Convert implements auth.Arguments.
-func (args Arguments) Convert() (otelcomponent.Config, error) {
+func (args Arguments) ConvertClient() (otelcomponent.Config, error) {
 	res := sigv4authextension.Config{
 		Region:     args.Region,
 		Service:    args.Service,
@@ -58,9 +60,13 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 	return &res, nil
 }
 
+func (args Arguments) ConvertServer() (otelcomponent.Config, error) {
+	return nil, fmt.Errorf("%w sigv4authplugin does not implement server authentication", auth.ErrNotServerExtension)
+}
+
 // Validate implements syntax.Validator.
 func (args Arguments) Validate() error {
-	_, err := args.Convert()
+	_, err := args.ConvertClient()
 	return err
 }
 

--- a/internal/component/otelcol/auth/sigv4/sigv4_test.go
+++ b/internal/component/otelcol/auth/sigv4/sigv4_test.go
@@ -173,9 +173,13 @@ func Test(t *testing.T) {
 		// Get the authentication extension from our component and use it to make a
 		// request to our test server.
 		exports := ctrl.Exports().(auth.Exports)
-		require.NotNil(t, exports.Handler.Extension, "handler extension is nil")
 
-		clientAuth, ok := exports.Handler.Extension.(extauth.Client)
+		ext, err := exports.Handler.GetExtension(auth.Client)
+		require.NoError(t, err)
+
+		require.NotNil(t, ext.Extension, "handler extension is nil")
+
+		clientAuth, ok := ext.Extension.(extauth.Client)
 		require.True(t, ok, "handler does not implement configauth.ClientAuthenticator")
 
 		rt, err := clientAuth.RoundTripper(http.DefaultTransport)

--- a/internal/component/otelcol/config_grpc.go
+++ b/internal/component/otelcol/config_grpc.go
@@ -44,7 +44,7 @@ func (args *GRPCServerArguments) Convert() *otelconfiggrpc.ServerConfig {
 	}
 
 	var auth *otelconfigauth.Authentication
-	if args.Auth != nil{
+	if args.Auth != nil {
 		auth = &otelconfigauth.Authentication{
 			AuthenticatorID: args.Auth.ID,
 		}
@@ -62,10 +62,10 @@ func (args *GRPCServerArguments) Convert() *otelconfiggrpc.ServerConfig {
 		MaxConcurrentStreams: args.MaxConcurrentStreams,
 		ReadBufferSize:       int(args.ReadBufferSize),
 		WriteBufferSize:      int(args.WriteBufferSize),
-		Keepalive: args.Keepalive.Convert(),
-		IncludeMetadata: args.IncludeMetadata,
-		Auth: auth,
-	}	
+		Keepalive:            args.Keepalive.Convert(),
+		IncludeMetadata:      args.IncludeMetadata,
+		Auth:                 auth,
+	}
 }
 
 // Extensions exposes extensions used by args.

--- a/internal/component/otelcol/config_grpc.go
+++ b/internal/component/otelcol/config_grpc.go
@@ -43,8 +43,10 @@ func (args *GRPCServerArguments) Convert() (*otelconfiggrpc.ServerConfig, error)
 		return nil, nil
 	}
 
+	// If auth is set add that to the config.
 	var authz *otelconfigauth.Authentication
 	if args.Auth != nil {
+		// If a auth plugin does not implement server auth, an error will be returned here.
 		serverExtension, err := args.Auth.GetExtension(auth.Server)
 		if err != nil {
 			return nil, err
@@ -183,7 +185,7 @@ func (args *GRPCClientArguments) Convert() (*otelconfiggrpc.ClientConfig, error)
 		opaqueHeaders[headerName] = configopaque.String(headerVal)
 	}
 
-	// Configure the authentication if args.Auth is set.
+	// Configure authentication if args.Auth is set.
 	var authz *otelconfigauth.Authentication
 	if args.Auth != nil {
 		ext, err := args.Auth.GetExtension(auth.Client)

--- a/internal/component/otelcol/config_http.go
+++ b/internal/component/otelcol/config_http.go
@@ -45,6 +45,8 @@ func (args *HTTPServerArguments) Convert() (*otelconfighttp.ServerConfig, error)
 		return nil, nil
 	}
 
+	// If auth is set by the user retrieve the associated extension from the handler.
+	// if the extension does not support server auth an error will be returned.
 	var authz *otelconfighttp.AuthConfig
 	if args.Auth != nil {
 		ext, err := args.Auth.GetExtension(auth.Server)
@@ -75,6 +77,7 @@ func (args *HTTPServerArguments) Extensions() map[otelcomponent.ID]otelextension
 	m := make(map[otelcomponent.ID]otelextension.Extension)
 	if args.Auth != nil {
 		ext, err := args.Auth.GetExtension(auth.Server)
+		// Extension will not be registered if there was an error.
 		if err != nil {
 			return m
 		}

--- a/internal/component/otelcol/exporter/otlp/otlp.go
+++ b/internal/component/otelcol/exporter/otlp/otlp.go
@@ -62,13 +62,18 @@ func (args *Arguments) SetToDefault() {
 
 // Convert implements exporter.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
+	clientArgs := *(*otelcol.GRPCClientArguments)(&args.Client)
+	convertedClientArgs, err := clientArgs.Convert()
+	if err != nil {
+		return nil, err
+	}
 	return &otlpexporter.Config{
 		TimeoutConfig: otelpexporterhelper.TimeoutConfig{
 			Timeout: args.Timeout,
 		},
 		QueueConfig:  *args.Queue.Convert(),
 		RetryConfig:  *args.Retry.Convert(),
-		ClientConfig: *(*otelcol.GRPCClientArguments)(&args.Client).Convert(),
+		ClientConfig: *convertedClientArgs,
 	}, nil
 }
 

--- a/internal/component/otelcol/exporter/otlphttp/otlphttp.go
+++ b/internal/component/otelcol/exporter/otlphttp/otlphttp.go
@@ -71,8 +71,13 @@ func (args *Arguments) SetToDefault() {
 
 // Convert implements exporter.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
+	httpClientArgs := *(*otelcol.HTTPClientArguments)(&args.Client)
+	convertedClientArgs, err := httpClientArgs.Convert()
+	if err != nil {
+		return nil, err
+	}
 	return &otlphttpexporter.Config{
-		ClientConfig:    *(*otelcol.HTTPClientArguments)(&args.Client).Convert(),
+		ClientConfig:    *convertedClientArgs,
 		QueueConfig:     *args.Queue.Convert(),
 		RetryConfig:     *args.Retry.Convert(),
 		TracesEndpoint:  args.TracesEndpoint,

--- a/internal/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
+++ b/internal/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
@@ -68,11 +68,29 @@ func (args *Arguments) SetToDefault() {
 
 // Convert implements extension.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
+	httpServerConfig := (*otelcol.HTTPServerArguments)(args.HTTP)
+	httpConvertedServerConfig, err := httpServerConfig.Convert()
+	if err != nil {
+		return nil, err
+	}
+
+	grpcServerConfig := (*otelcol.GRPCServerArguments)(args.GRPC)
+	convertedGrpcServerConfig, err := grpcServerConfig.Convert()
+	if err != nil {
+		return nil, err
+	}
+
+	grpcClientConfig := (*otelcol.GRPCClientArguments)(args.Source.Remote)
+	convertedGrpcClientConfig, err := grpcClientConfig.Convert()
+	if err != nil {
+		return nil, err
+	}
+
 	return &jaegerremotesampling.Config{
-		HTTPServerConfig: (*otelcol.HTTPServerArguments)(args.HTTP).Convert(),
-		GRPCServerConfig: (*otelcol.GRPCServerArguments)(args.GRPC).Convert(),
+		HTTPServerConfig: httpConvertedServerConfig,
+		GRPCServerConfig: convertedGrpcServerConfig,
 		Source: jaegerremotesampling.Source{
-			Remote:         (*otelcol.GRPCClientArguments)(args.Source.Remote).Convert(),
+			Remote:         convertedGrpcClientConfig,
 			File:           args.Source.File,
 			ReloadInterval: args.Source.ReloadInterval,
 			Contents:       args.Source.Content,

--- a/internal/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
+++ b/internal/component/otelcol/extension/jaeger_remote_sampling/jaeger_remote_sampling.go
@@ -2,6 +2,7 @@ package jaeger_remote_sampling
 
 import (
 	"fmt"
+	"maps"
 	"time"
 
 	"github.com/grafana/alloy/internal/component"
@@ -100,7 +101,24 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 
 // Extensions implements extension.Arguments.
 func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
-	return nil
+	extensionMap := make(map[otelcomponent.ID]otelextension.Extension)
+
+	// Gets the extensions for the HTTP server and GRPC server
+	if args.HTTP != nil {
+		httpExtensions := (*otelcol.HTTPServerArguments)(args.HTTP).Extensions()
+
+		// Copies the extensions for the HTTP server into the map
+		maps.Copy(extensionMap, httpExtensions)
+	}
+
+	if args.GRPC != nil {
+		grpcExtensions := (*otelcol.GRPCServerArguments)(args.GRPC).Extensions()
+
+		// Copies the extensions for the GRPC server into the map.
+		maps.Copy(extensionMap, grpcExtensions)
+	}
+
+	return extensionMap
 }
 
 // Exporters implements extension.Arguments.

--- a/internal/component/otelcol/receiver/datadog/datadog.go
+++ b/internal/component/otelcol/receiver/datadog/datadog.go
@@ -57,8 +57,13 @@ func (args *Arguments) SetToDefault() {
 
 // Convert implements receiver.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
+	convertedHttpServer, err := args.HTTPServer.Convert()
+	if err != nil {
+		return nil, err
+	}
+
 	return &datadogreceiver.Config{
-		ServerConfig: *args.HTTPServer.Convert(),
+		ServerConfig: *convertedHttpServer,
 		ReadTimeout:  args.ReadTimeout,
 	}, nil
 }

--- a/internal/component/otelcol/receiver/datadog/datadog.go
+++ b/internal/component/otelcol/receiver/datadog/datadog.go
@@ -70,7 +70,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 
 // Extensions implements receiver.Arguments.
 func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
-	return nil
+	return args.HTTPServer.Extensions()
 }
 
 // Exporters implements receiver.Arguments.

--- a/internal/component/otelcol/receiver/jaeger/jaeger.go
+++ b/internal/component/otelcol/receiver/jaeger/jaeger.go
@@ -90,14 +90,14 @@ func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension 
 	extensionMap := make(map[otelcomponent.ID]otelextension.Extension)
 
 	// Gets the extensions for the HTTP server and GRPC server
-	if args.Protocols.ThriftHTTP != nil {
+	if args.Protocols.ThriftHTTP != nil && args.Protocols.ThriftHTTP.HTTPServerArguments != nil {
 		httpExtensions := (*otelcol.HTTPServerArguments)(args.Protocols.ThriftHTTP.HTTPServerArguments).Extensions()
 
 		// Copies the extensions for the HTTP server into the map
 		maps.Copy(extensionMap, httpExtensions)
 	}
 
-	if args.Protocols.GRPC.GRPCServerArguments != nil {
+	if args.Protocols.GRPC != nil && args.Protocols.GRPC.GRPCServerArguments != nil {
 		grpcExtensions := (*otelcol.GRPCServerArguments)(args.Protocols.GRPC.GRPCServerArguments).Extensions()
 
 		// Copies the extensions for the GRPC server into the map.

--- a/internal/component/otelcol/receiver/jaeger/jaeger.go
+++ b/internal/component/otelcol/receiver/jaeger/jaeger.go
@@ -3,6 +3,7 @@ package jaeger
 
 import (
 	"fmt"
+	"maps"
 
 	"github.com/alecthomas/units"
 	"github.com/grafana/alloy/internal/component"
@@ -86,7 +87,24 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 
 // Extensions implements receiver.Arguments.
 func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
-	return nil
+	extensionMap := make(map[otelcomponent.ID]otelextension.Extension)
+
+	// Gets the extensions for the HTTP server and GRPC server
+	if args.Protocols.ThriftHTTP != nil {
+		httpExtensions := (*otelcol.HTTPServerArguments)(args.Protocols.ThriftHTTP.HTTPServerArguments).Extensions()
+
+		// Copies the extensions for the HTTP server into the map
+		maps.Copy(extensionMap, httpExtensions)
+	}
+
+	if args.Protocols.GRPC.GRPCServerArguments != nil {
+		grpcExtensions := (*otelcol.GRPCServerArguments)(args.Protocols.GRPC.GRPCServerArguments).Extensions()
+
+		// Copies the extensions for the GRPC server into the map.
+		maps.Copy(extensionMap, grpcExtensions)
+	}
+
+	return extensionMap
 }
 
 // Exporters implements receiver.Arguments.

--- a/internal/component/otelcol/receiver/jaeger/jaeger.go
+++ b/internal/component/otelcol/receiver/jaeger/jaeger.go
@@ -65,10 +65,19 @@ func (args *Arguments) Validate() error {
 
 // Convert implements receiver.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
+	grpcProtocol, err := args.Protocols.GRPC.Convert()
+	if err != nil {
+		return nil, err
+	}
+
+	httpProtocol, err := args.Protocols.ThriftHTTP.Convert()
+	if err != nil {
+		return nil, err
+	}
 	return &jaegerreceiver.Config{
 		Protocols: jaegerreceiver.Protocols{
-			GRPC:          args.Protocols.GRPC.Convert(),
-			ThriftHTTP:    args.Protocols.ThriftHTTP.Convert(),
+			GRPC:          grpcProtocol,
+			ThriftHTTP:    httpProtocol,
 			ThriftBinary:  args.Protocols.ThriftBinary.Convert(),
 			ThriftCompact: args.Protocols.ThriftCompact.Convert(),
 		},
@@ -114,9 +123,9 @@ func (args *GRPC) SetToDefault() {
 }
 
 // Convert converts proto into the upstream type.
-func (args *GRPC) Convert() *otelconfiggrpc.ServerConfig {
+func (args *GRPC) Convert() (*otelconfiggrpc.ServerConfig, error) {
 	if args == nil {
-		return nil
+		return nil, nil
 	}
 
 	return args.GRPCServerArguments.Convert()
@@ -137,9 +146,9 @@ func (args *ThriftHTTP) SetToDefault() {
 }
 
 // Convert converts proto into the upstream type.
-func (args *ThriftHTTP) Convert() *otelconfighttp.ServerConfig {
+func (args *ThriftHTTP) Convert() (*otelconfighttp.ServerConfig, error) {
 	if args == nil {
-		return nil
+		return nil, nil
 	}
 
 	return args.HTTPServerArguments.Convert()

--- a/internal/component/otelcol/receiver/opencensus/opencensus.go
+++ b/internal/component/otelcol/receiver/opencensus/opencensus.go
@@ -70,7 +70,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 
 // Extensions implements receiver.Arguments.
 func (args Arguments) Extensions() map[otelcomponent.ID]extension.Extension {
-	return nil
+	return args.GRPC.Extensions()
 }
 
 // Exporters implements receiver.Arguments.

--- a/internal/component/otelcol/receiver/opencensus/opencensus.go
+++ b/internal/component/otelcol/receiver/opencensus/opencensus.go
@@ -58,9 +58,13 @@ func (args *Arguments) SetToDefault() {
 
 // Convert implements receiver.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
+	grpcServerConfig, err := args.GRPC.Convert()
+	if err != nil {
+		return nil, err
+	}
 	return &opencensusreceiver.Config{
 		CorsOrigins:  args.CorsAllowedOrigins,
-		ServerConfig: *args.GRPC.Convert(),
+		ServerConfig: *grpcServerConfig,
 	}, nil
 }
 

--- a/internal/component/otelcol/receiver/otlp/otlp.go
+++ b/internal/component/otelcol/receiver/otlp/otlp.go
@@ -93,21 +93,19 @@ func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension 
 	extensionMap := make(map[otelcomponent.ID]otelextension.Extension)
 
 	// Gets the extensions for the HTTP server and GRPC server
-	if args.HTTP != nil{
-		httpExtensions :=  (*otelcol.HTTPServerArguments)(args.HTTP.HTTPServerArguments).Extensions()
+	if args.HTTP != nil {
+		httpExtensions := (*otelcol.HTTPServerArguments)(args.HTTP.HTTPServerArguments).Extensions()
 
-		// Copies the extensions from each server.
+		// Copies the extensions for the HTTP server into the map
 		maps.Copy(extensionMap, httpExtensions)
 	}
 
-	if args.GRPC != nil{
+	if args.GRPC != nil {
 		grpcExtensions := (*otelcol.GRPCServerArguments)(args.GRPC).Extensions()
 
-		// Copies the extensions from each server.
+		// Copies the extensions for the GRPC server into the map.
 		maps.Copy(extensionMap, grpcExtensions)
 	}
-	
-	
 
 	return extensionMap
 }

--- a/internal/component/otelcol/receiver/otlp/otlp.go
+++ b/internal/component/otelcol/receiver/otlp/otlp.go
@@ -3,6 +3,7 @@ package otlp
 
 import (
 	"fmt"
+	"maps"
 	net_url "net/url"
 
 	"github.com/alecthomas/units"
@@ -89,7 +90,26 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 
 // Extensions implements receiver.Arguments.
 func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
-	return nil
+	extensionMap := make(map[otelcomponent.ID]otelextension.Extension)
+
+	// Gets the extensions for the HTTP server and GRPC server
+	if args.HTTP != nil{
+		httpExtensions :=  (*otelcol.HTTPServerArguments)(args.HTTP.HTTPServerArguments).Extensions()
+
+		// Copies the extensions from each server.
+		maps.Copy(extensionMap, httpExtensions)
+	}
+
+	if args.GRPC != nil{
+		grpcExtensions := (*otelcol.GRPCServerArguments)(args.GRPC).Extensions()
+
+		// Copies the extensions from each server.
+		maps.Copy(extensionMap, grpcExtensions)
+	}
+	
+	
+
+	return extensionMap
 }
 
 // Exporters implements receiver.Arguments.

--- a/internal/component/otelcol/receiver/zipkin/zipkin.go
+++ b/internal/component/otelcol/receiver/zipkin/zipkin.go
@@ -54,9 +54,13 @@ func (args *Arguments) SetToDefault() {
 
 // Convert implements receiver.Arguments.
 func (args Arguments) Convert() (otelcomponent.Config, error) {
+	httpServerConfig, err := args.HTTPServer.Convert()
+	if err != nil {
+		return nil, err
+	}
 	return &zipkinreceiver.Config{
 		ParseStringTags: args.ParseStringTags,
-		ServerConfig:    *args.HTTPServer.Convert(),
+		ServerConfig:    *httpServerConfig,
 	}, nil
 }
 

--- a/internal/component/otelcol/receiver/zipkin/zipkin.go
+++ b/internal/component/otelcol/receiver/zipkin/zipkin.go
@@ -66,7 +66,7 @@ func (args Arguments) Convert() (otelcomponent.Config, error) {
 
 // Extensions implements receiver.Arguments.
 func (args Arguments) Extensions() map[otelcomponent.ID]otelextension.Extension {
-	return nil
+	return args.HTTPServer.Extensions()
 }
 
 // Exporters implements receiver.Arguments.


### PR DESCRIPTION
#### PR Description
Adds server authentication support to `otelcol.receivers.*` that support the OpenTelemetry collector auth extension model. Some receivers are not wrappers of the collector so they are excluded from this PR. 

Receivers that now support server auth:
- Datadog
- Jaeger
- Otlp
- Opencensus
- Zipkin
- Jaeger_Remote_Sampling

#### Which issue(s) this PR fixes

Fixes #229

#### Notes to the Reviewer
TestAuthServer in auth_basic_test.go is consistently failing due to a race condition in startup. Any ideas or potential solutions to this problem would be appreciated. The auth_basic plugin appears to function as expected when running from the binary. 

User interface for client auth has not changed.

#### PR Checklist

- [ x ] CHANGELOG.md updated
- [ x ] Documentation added
- [ x ] Tests updated

